### PR TITLE
修复一处可能导致编译失败的错误

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ function genProdWebviewCode(cache: Record<string, string>, webview?: WebviewOpti
 
   const cacheCode = /* js */ `const htmlCode = {
     ${Object.keys(cache)
-      .map(s => `${s}: \`${handleHtmlCode(cache[s])}\`,`)
+      .map(s => `'${s}': \`${handleHtmlCode(cache[s])}\`,`)
       .join('\n')}
   };`;
 


### PR DESCRIPTION
当我的入口文件名中包含 `-` 字符时会出现一个错误 使用引号包裹应该会解决这个问题