### PR TITLE
chore: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ process.env.VITE_DEV_SERVER_URL
 
 ```ts
 process.env.VITE_DEV_SERVER_URL
-  ? __getWebviewHtml__(`${process.env.VITE_DEV_SERVER_URL}/index2.html`)
+  ? __getWebviewHtml__(`${process.env.VITE_DEV_SERVER_URL}index2.html`)
   : __getWebviewHtml__(webview, context, 'index2');
 ```
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -179,7 +179,7 @@ process.env.VITE_DEV_SERVER_URL
 
 ```ts
 process.env.VITE_DEV_SERVER_URL
-  ? __getWebviewHtml__(`${process.env.VITE_DEV_SERVER_URL}/index2.html`)
+  ? __getWebviewHtml__(`${process.env.VITE_DEV_SERVER_URL}index2.html`)
   : __getWebviewHtml__(webview, context, 'index2');
 ```
 


### PR DESCRIPTION
`http://localhost:5173//index2.html` have nothing